### PR TITLE
Fix Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Simply pick the `open` extension from the list.
 
 The extension can also be executed on demand
 
-- **Mac**: <kbd>Control</kbd> + <kbd>Alt</kbd> + <kbd>O</kbd>
-- **Windows**: <kbd>Command</kbd> + <kbd>Alt</kbd> + <kbd>O</kbd>
+- **Mac**: <kbd>Command</kbd> + <kbd>Alt</kbd> + <kbd>O</kbd>
+- **Windows**: <kbd>Control</kbd> + <kbd>Alt</kbd> + <kbd>O</kbd>
 
 The command could also be found in the command palette (named `Open with default application`), or on the contextual menu in the file explorer.
 


### PR DESCRIPTION
Shortcuts for Mac and Windows were reversed. Fixed. 

- Mac should be: Command + Alt + O; Was: Control + Alt + O
- Windows should be: Control + Alt + O; Was: Command + Alt + O